### PR TITLE
Update intro.tex

### DIFF
--- a/intro.tex
+++ b/intro.tex
@@ -1,12 +1,6 @@
 \chapter{Introduction}
 
-This is the RISC-V XBitmanip Extension draft spec. Originally it was the
-B-Extension draft spec, but the work group got dissolved for bureaucratic
-reasons in November 2017.
-
-It is currently an independently maintained document. We'd happily donate
-it to the RISC-V foundation as starting point for a new B-Extension work
-group, if there will be one.
+This is the RISC-V Bitmanip Extension draft spec. 
 
 \section{ISA Extension Proposal Design Criteria}
 
@@ -23,8 +17,8 @@ criteria.
 \item
   Threshold Metric: The proposal should provide a \emph{significant}
   savings in terms of clocks or instructions. As a heuristic, any
-  proposal should replace at least four instructions. An instruction
-  that only replaces three may be considered, but only if the frequency
+  proposal should replace at least three instructions. An instruction
+  that only replaces two may be considered, but only if the frequency
   of use is very high and/or the implementation very cheap.
 \item
   Data-Driven Value: Usage in real world applications, and corresponding


### PR DESCRIPTION
Since we are an official group, references to an unofficial group or the dissolution of the old group should be removed.
I also changed the threshold as I think replacing 4 instruction might be too high. Of course, this all depends on the context. Saving 3 instructions one in a long stream of instructions might not even be a blip on the radar, but saving  2 instructions in a tight loop could have a significant impact on performance.